### PR TITLE
fix: explicitly cd to project dir in every non-first pane

### DIFF
--- a/scripts/layout-dynamic.applescript
+++ b/scripts/layout-dynamic.applescript
@@ -60,12 +60,6 @@ on run argv
                 set frontmost to true
                 delay 0.5
 
-                -- cd to project directory (this is pane 1, spatial position 0)
-                set the clipboard to "cd " & (quoted form of projectDir) & " && clear"
-                keystroke "v" using {command down}
-                key code 36 -- Enter
-                delay 0.5
-
                 -- PHASE 1: Create row spine (n-1 vertical splits)
                 -- This creates one anchor pane per row
                 if numRows > 1 then
@@ -90,16 +84,6 @@ on run argv
                 repeat with rowIdx from 1 to numRows
                     set panesInRow to item rowIdx of rowCounts
 
-                    -- Ensure non-first panes start in project directory
-                    -- (pane 1 already got cd at start; row 2+ anchors
-                    -- may not inherit if pane 1 is running a foreground process)
-                    if spatialIdx > 1 then
-                        set the clipboard to "cd " & (quoted form of projectDir) & " && clear"
-                        keystroke "v" using {command down}
-                        key code 36 -- Enter
-                        delay 0.3
-                    end if
-
                     -- Type command for this row's anchor (we're already here)
                     if spatialIdx <= (count of commands) then
                         set cmd to item spatialIdx of commands
@@ -117,12 +101,6 @@ on run argv
                         repeat panesInRow - 1 times
                             keystroke "d" using {command down} -- Split right
                             delay 0.6 -- Increased for split stability
-
-                            -- Ensure split pane starts in project directory
-                            set the clipboard to "cd " & (quoted form of projectDir) & " && clear"
-                            keystroke "v" using {command down}
-                            key code 36 -- Enter
-                            delay 0.3
 
                             -- Now in the new split pane, type its command
                             if spatialIdx <= (count of commands) then

--- a/scripts/layout-hybrid.applescript
+++ b/scripts/layout-hybrid.applescript
@@ -75,12 +75,6 @@ on run argv
                     -- cmdIndex = (tabIdx - 1) * panesPerTab + spatialIdx
                     set tabCmdBase to (tabIdx - 1) * panesPerTab
 
-                    -- cd to project directory (this is pane 1 of current tab)
-                    set the clipboard to "cd " & (quoted form of projectDir) & " && clear"
-                    keystroke "v" using {command down}
-                    key code 36 -- Enter
-                    delay 0.5
-
                     -- === PHASE 1: Create row spine (n-1 vertical splits) ===
                     -- This creates one anchor pane per row
                     if numRows > 1 then
@@ -105,16 +99,6 @@ on run argv
                     repeat with rowIdx from 1 to numRows
                         set panesInRow to item rowIdx of rowCounts
 
-                        -- Ensure non-first panes start in project directory
-                        -- (pane 1 already got cd at tab start; row 2+ anchors
-                        -- may not inherit if pane 1 is running a foreground process)
-                        if spatialIdx > 1 then
-                            set the clipboard to "cd " & (quoted form of projectDir) & " && clear"
-                            keystroke "v" using {command down}
-                            key code 36 -- Enter
-                            delay 0.3
-                        end if
-
                         -- Type command for this row's anchor (we're already here)
                         set cmdIndex to tabCmdBase + spatialIdx
                         if cmdIndex <= (count of commands) then
@@ -133,12 +117,6 @@ on run argv
                             repeat panesInRow - 1 times
                                 keystroke "d" using {command down} -- Split right
                                 delay 0.6 -- Increased for split stability
-
-                                -- Ensure split pane starts in project directory
-                                set the clipboard to "cd " & (quoted form of projectDir) & " && clear"
-                                keystroke "v" using {command down}
-                                key code 36 -- Enter
-                                delay 0.3
 
                                 -- Now in the new split pane, type its command
                                 set cmdIndex to tabCmdBase + spatialIdx


### PR DESCRIPTION
## Summary

- Panes created after pane 1 relied on Ghostty's directory inheritance, which breaks when pane 1 runs a foreground process (e.g. `claude`, `npm run dev`) — Ghostty can't resolve CWD from a busy shell, so splits start in `~`
- Now every non-first pane gets an explicit `cd /project && clear` before its command, using a separate paste step (not concatenated) to preserve user commands exactly
- Applied consistently to both `layout-dynamic.applescript` and `layout-hybrid.applescript`

## What changed

**Phase 2 anchor panes** (row 2+ in multi-row layouts):
- Added `cd && clear` when `spatialIdx > 1` (pane 1 already has cd)

**Phase 2 horizontal split panes** (all `Cmd+D` splits):
- Added `cd && clear` after every split — always non-first by definition

## Timing impact

+0.3s per non-first pane. For a quad layout (4 panes): +0.9s total on ~6s setup.

## Test plan

- [x] `./tests/test-layouts.zsh` — 33/33 pass
- [x] `--dry-run` unaffected (exits before AppleScript)
- [ ] Manual: `gpane <project>` with duo layout — verify pane 2 starts in project dir
- [ ] Manual: quad layout — verify all 4 panes start in project dir
- [ ] Manual: tabs+panes hybrid — verify across tabs