### PR TITLE
feat(config): add config option for --here default window behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **Config option for `--here` default**: `current_window: true` (or `reuse_window: true`) in config makes gpane use the current Ghostty window by default instead of opening a new one; passing `--here` / `--current-window` on the CLI still works and takes precedence
+
 ## [0.3.1] - 2026-02-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Config lives at `~/.config/gpane/config.yaml` (new installs) or `~/.config/gsx/c
 ```yaml
 projects_root: ~/Projects
 default_layout: quad
+current_window: true  # Optional: default to --here behavior
 
 # Commands for each pane (left-to-right, top-to-bottom)
 default_commands:

--- a/bin/gpane
+++ b/bin/gpane
@@ -23,6 +23,7 @@ source "${GPANE_ROOT}/lib/setup.zsh"
 # Global flags
 DRY_RUN=false
 REUSE_WINDOW=false
+REUSE_WINDOW_EXPLICIT=false
 
 # Open session for a project
 # Sets PROJECT_LAYOUT as side effect (for caller to use in header)
@@ -96,7 +97,10 @@ main() {
   # Check for flags anywhere in args
   for arg in "$@"; do
     [[ "${arg}" == "--dry-run" ]] && DRY_RUN=true
-    [[ "${arg}" == "--here" || "${arg}" == "--current-window" ]] && REUSE_WINDOW=true
+    if [[ "${arg}" == "--here" || "${arg}" == "--current-window" ]]; then
+      REUSE_WINDOW=true
+      REUSE_WINDOW_EXPLICIT=true
+    fi
   done
 
   # Skip preflight for help/version
@@ -138,6 +142,9 @@ main() {
         check_for_updates
         [[ "${DRY_RUN}" == false ]] && check_ghostty
         parse_config
+        if [[ "${REUSE_WINDOW_EXPLICIT}" == false && "${DEFAULT_REUSE_WINDOW}" == true ]]; then
+          REUSE_WINDOW=true
+        fi
         interactive_select || exit 1
 
         local count=${#SELECTED_PROJECTS[@]}
@@ -168,6 +175,9 @@ main() {
       check_for_updates
       [[ "${DRY_RUN}" == false ]] && check_ghostty
       parse_config
+      if [[ "${REUSE_WINDOW_EXPLICIT}" == false && "${DEFAULT_REUSE_WINDOW}" == true ]]; then
+        REUSE_WINDOW=true
+      fi
       local project_dir
       project_dir=$(resolve_project_dir "${cmd}") || exit 1
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -13,6 +13,9 @@ default_layout: duo
 # If omitted or set to 1, creates a single window with the layout above
 # tabs: 3
 
+# Optional: Reuse current Ghostty window by default (same as --here)
+# current_window: true
+
 # Default commands for each section (empty string = just shell)
 # Commands fill in order: left-to-right, top-to-bottom
 # For multiple tabs: tab1-section1, tab1-section2, tab2-section1, tab2-section2, ...

--- a/lib/config.zsh
+++ b/lib/config.zsh
@@ -19,6 +19,7 @@ CONFIG_FILE="${CONFIG_DIR}/config.yaml"
 PROJECTS_ROOT=""
 DEFAULT_LAYOUT="3-col"
 TABS_COUNT=1  # Number of tabs (1 = single window, 2-10 = multiple tabs)
+DEFAULT_REUSE_WINDOW=false  # true = default to --here behavior
 
 # Array of commands in spatial order (left-to-right, top-to-bottom)
 typeset -a PANE_COMMANDS
@@ -33,6 +34,7 @@ parse_config() {
   PROJECTS_ROOT=""
   DEFAULT_LAYOUT="3-col"
   TABS_COUNT=1
+  DEFAULT_REUSE_WINDOW=false
   PANE_COMMANDS=()
 
   local line in_commands=false
@@ -61,6 +63,15 @@ parse_config() {
       DEFAULT_LAYOUT="${match[1]}"
     elif [[ "${line}" =~ ^tabs:[[:space:]]*([0-9]+)$ ]]; then
       TABS_COUNT="${match[1]}"
+    elif [[ "${line}" =~ ^(current_window|reuse_window):[[:space:]]*(.+)$ ]]; then
+      local bool_value="${match[2]}"
+      bool_value="${bool_value//\"/}"
+      bool_value="${bool_value//\'/}"
+      bool_value="${bool_value:l}"
+      case "${bool_value}" in
+        true|yes|1|on) DEFAULT_REUSE_WINDOW=true ;;
+        false|no|0|off) DEFAULT_REUSE_WINDOW=false ;;
+      esac
     fi
 
     # Parse default commands (array format: "- value")

--- a/lib/help.zsh
+++ b/lib/help.zsh
@@ -21,6 +21,7 @@ Options:
   --here, --current-window
                           Use current Ghostty window instead of creating new one
                           (For multiple projects, only the first uses current window)
+                          Tip: set 'current_window: true' in config to make this default
 
 Layouts:
   Row notation: "2" (2 side-by-side), "2-2" (4-pane grid), "1-3" (1 top + 3 bottom)

--- a/lib/setup.zsh
+++ b/lib/setup.zsh
@@ -178,6 +178,8 @@ setup_wizard() {
 projects_root: ${projects_root}
 default_layout: ${default_layout}
 ${tabs_yaml}
+# Optional: same as passing --here
+# current_window: true
 
 default_commands:
 $(echo -e "${commands_yaml}")


### PR DESCRIPTION
## Summary

Adds a config option so users can make **“use current window”** the default behavior instead of passing `--here` / `--current-window` every time.

## Changes

- **Config:** New optional key `current_window: true` (alias `reuse_window: true`) in `~/.config/gpane/config.yaml`. When set, gpane reuses the current Ghostty window by default.
- **CLI:** Explicit `--here` / `--current-window` on the command line still works and is unchanged; the config default only applies when the flag is not passed.
- **Docs:** README and `config.example.yaml` updated; help text mentions the config tip.

## Behavior

- **Without config / `current_window: false`:** Unchanged — new window unless user passes `--here`.
- **With `current_window: true`:** Same as always passing `--here`; opening in current window is the default. User can still get a new window by not setting the option or by overriding in a future change if desired.
- **Explicit `--here`:** Always reuses current window, whether or not config is set.

## Checklist

- [x] Conventional Commits style commit message
- [x] CHANGELOG.md updated (Keep a Changelog)
- [x] Config example and README updated
- [x] No breaking change; existing configs and CLI behavior unchanged when option not set

## Test Plan

- [x] **Default (no config):** With no `current_window` (or `reuse_window`) in config, `gpane <project>` opens a **new** Ghostty window. `gpane <project> --here` reuses current window.
- [x] **Config default on:** Add `current_window: true` to `~/.config/gpane/config.yaml`. Run `gpane <project>` (no flags) from inside Ghostty → panes open in **current** window. Run `gpane <project> --here` → same behavior.
- [x] **Config default off:** Set `current_window: false` (or omit). `gpane <project>` opens a **new** window again.
- [x] **Alias:** `reuse_window: true` in config behaves the same as `current_window: true`.
- [x] **Values:** Confirm `yes`/`1`/`on` and `no`/`0`/`off` parse correctly (e.g. `current_window: yes` → reuse by default).
- [x] **Interactive picker:** With `current_window: true`, run `gpane` (no project name), pick a project → opens in current window.
- [x] **Help:** `gpane help` shows the tip about setting `current_window: true` in config under the `--here` option.

(Optional: use `gpane <project> --dry-run` where useful to confirm flow without opening windows.)