### PR TITLE
feat: add column-first layout support

### DIFF
--- a/lib/layouts.zsh
+++ b/lib/layouts.zsh
@@ -19,6 +19,8 @@ LAYOUT_ALIASES[stacked]="1-1"
 LAYOUT_ALIASES[quad]="2-2"
 LAYOUT_ALIASES[dashboard]="1-3"
 LAYOUT_ALIASES[wide]="3-1"
+LAYOUT_ALIASES[main-side]="1|2"
+LAYOUT_ALIASES[side-main]="2|1"
 
 # Resolve layout alias to row notation
 # Usage: resolve_layout_alias "quad" -> "2-2"
@@ -45,11 +47,18 @@ parse_layout_spec() {
 # Compute total panes from layout spec
 compute_total_panes() {
     local spec=$1
-    local -a rows=(${(s:-:)spec})
     local total=0
-    for r in "${rows[@]}"; do
-        total=$((total + r))
-    done
+    if [[ "$spec" == *"|"* ]]; then
+        local -a cols=(${(s:|:)spec})
+        for c in "${cols[@]}"; do
+            total=$((total + c))
+        done
+    else
+        local -a rows=(${(s:-:)spec})
+        for r in "${rows[@]}"; do
+            total=$((total + r))
+        done
+    fi
     echo $total
 }
 
@@ -76,31 +85,47 @@ prepend_cd_to_commands() {
 validate_layout() {
     local spec=$1
 
-    # Must match pattern: digits separated by dashes
-    if [[ ! "$spec" =~ ^[1-9](-[1-9])*$ ]]; then
-        echo "Invalid layout format: $spec (must be like '2', '2-2', '1-3')" >&2
-        return 1
-    fi
-
-    local -a rows=(${(s:-:)spec})
-    local num_rows=${#rows[@]}
-    local total=0
-
-    # Max 4 rows
-    if ((num_rows > 4)); then
-        echo "Too many rows: $num_rows (max 4)" >&2
-        return 1
-    fi
-
-    # Count total panes
-    for r in "${rows[@]}"; do
-        total=$((total + r))
-    done
-
-    # Max 10 panes
-    if ((total > 10)); then
-        echo "Too many panes: $total (max 10)" >&2
-        return 1
+    # Column layout uses | delimiter, row layout uses -
+    if [[ "$spec" == *"|"* ]]; then
+        # Column layout: digits separated by pipes
+        if [[ ! "$spec" =~ '^[1-9]([|][1-9])*$' ]]; then
+            echo "Invalid column layout format: $spec (must be like '1|2', '2|1|2')" >&2
+            return 1
+        fi
+        local -a cols=(${(s:|:)spec})
+        local num_cols=${#cols[@]}
+        local total=0
+        if ((num_cols > 4)); then
+            echo "Too many columns: $num_cols (max 4)" >&2
+            return 1
+        fi
+        for c in "${cols[@]}"; do
+            total=$((total + c))
+        done
+        if ((total > 10)); then
+            echo "Too many panes: $total (max 10)" >&2
+            return 1
+        fi
+    else
+        # Row layout: digits separated by dashes
+        if [[ ! "$spec" =~ ^[1-9](-[1-9])*$ ]]; then
+            echo "Invalid layout format: $spec (must be like '2', '2-2', '1-3')" >&2
+            return 1
+        fi
+        local -a rows=(${(s:-:)spec})
+        local num_rows=${#rows[@]}
+        local total=0
+        if ((num_rows > 4)); then
+            echo "Too many rows: $num_rows (max 4)" >&2
+            return 1
+        fi
+        for r in "${rows[@]}"; do
+            total=$((total + r))
+        done
+        if ((total > 10)); then
+            echo "Too many panes: $total (max 10)" >&2
+            return 1
+        fi
     fi
 
     return 0
@@ -126,6 +151,8 @@ get_layout_info() {
         2-2) LAYOUT_PANE_COUNT=4; LAYOUT_PANE_LABELS=("Top-left" "Top-right" "Bottom-left" "Bottom-right") ;;
         1-3) LAYOUT_PANE_COUNT=4; LAYOUT_PANE_LABELS=("Top (main)" "Bottom-left" "Bottom-middle" "Bottom-right") ;;
         3-1) LAYOUT_PANE_COUNT=4; LAYOUT_PANE_LABELS=("Top-left" "Top-middle" "Top-right" "Bottom (main)") ;;
+        '1|2') LAYOUT_PANE_COUNT=3; LAYOUT_PANE_LABELS=("Left (main)" "Right-top" "Right-bottom") ;;
+        '2|1') LAYOUT_PANE_COUNT=3; LAYOUT_PANE_LABELS=("Left-top" "Left-bottom" "Right (main)") ;;
         *)
             # Custom layout - count panes from spec
             LAYOUT_PANE_COUNT=$(compute_total_panes "$resolved")
@@ -176,7 +203,13 @@ layout_hybrid() {
     done
 
     prepend_cd_to_commands "${project_dir}" "${cmds[@]}"
-    run_layout "layout-hybrid" "${label}" "${reuse_window}" "${project_dir}" "${layout_spec}" "${tabs_count}" "${PREPARED_COMMANDS[@]}"
+
+    # Route to column layout script if spec uses | delimiter
+    if [[ "$layout_spec" == *"|"* ]]; then
+        run_layout "layout-column" "${label}" "${reuse_window}" "${project_dir}" "${layout_spec}" "tabs:${tabs_count}" "${PREPARED_COMMANDS[@]}"
+    else
+        run_layout "layout-hybrid" "${label}" "${reuse_window}" "${project_dir}" "${layout_spec}" "${tabs_count}" "${PREPARED_COMMANDS[@]}"
+    fi
 }
 
 # Check for deprecated layout: tabs syntax
@@ -231,7 +264,13 @@ layout_dynamic() {
     done
 
     prepend_cd_to_commands "${project_dir}" "${spatial_cmds[@]}"
-    run_layout "layout-dynamic" "${label}" "${reuse_window}" "${project_dir}" "${layout_spec}" "${PREPARED_COMMANDS[@]}"
+
+    # Route to column layout script if spec uses | delimiter
+    if [[ "$layout_spec" == *"|"* ]]; then
+        run_layout "layout-column" "${label}" "${reuse_window}" "${project_dir}" "${layout_spec}" "${PREPARED_COMMANDS[@]}"
+    else
+        run_layout "layout-dynamic" "${label}" "${reuse_window}" "${project_dir}" "${layout_spec}" "${PREPARED_COMMANDS[@]}"
+    fi
 }
 
 # Run a layout script with progress dots

--- a/scripts/layout-column.applescript
+++ b/scripts/layout-column.applescript
@@ -1,0 +1,253 @@
+-- gpane column layout: column-first pane configuration
+-- Supports both single-window and multi-tab modes
+-- Single-window args: reuseWindow, projectDir, layoutSpec, cmd1, cmd2, ...
+-- Multi-tab args:     reuseWindow, projectDir, layoutSpec, "tabs:N", cmd1, cmd2, ...
+-- layoutSpec: "1|2" means col1 has 1 row, col2 has 2 rows (stacked vertically)
+-- Commands are in SPATIAL order (column by column, top-to-bottom within each column)
+-- Commands are typed DURING pane creation for reliability
+
+on run argv
+    set reuseWindow to item 1 of argv
+    set projectDir to item 2 of argv
+    set layoutSpec to item 3 of argv
+
+    -- Detect tabs mode: item 4 starts with "tabs:"
+    set tabsCount to 1
+    set cmdStartIdx to 4
+    if (count of argv) > 3 then
+        set maybeTabsArg to item 4 of argv
+        if maybeTabsArg starts with "tabs:" then
+            set tabsCount to (text 6 thru -1 of maybeTabsArg) as integer
+            set cmdStartIdx to 5
+        end if
+    end if
+
+    -- Try to save current clipboard (may fail for some content types)
+    set originalClipboard to missing value
+    try
+        set originalClipboard to the clipboard
+    end try
+
+    -- Parse commands
+    set commands to {}
+    if (count of argv) ≥ cmdStartIdx then
+        repeat with i from cmdStartIdx to (count of argv)
+            set end of commands to item i of argv
+        end repeat
+    end if
+
+    -- Parse layout spec "1|2" into list {1, 2}
+    set colCounts to parseColumnLayout(layoutSpec)
+    set numCols to count of colCounts
+
+    -- Calculate total panes per tab
+    set panesPerTab to 0
+    repeat with c in colCounts
+        set panesPerTab to panesPerTab + c
+    end repeat
+
+    -- Activate Ghostty
+    try
+        tell application "Ghostty" to activate
+    on error errMsg
+        error "Cannot activate Ghostty: " & errMsg
+    end try
+
+    delay 0.3
+
+    try
+        tell application "System Events"
+            if not (exists process "Ghostty") then
+                error "Ghostty process not found. Is Ghostty running?"
+            end if
+
+            tell process "Ghostty"
+                -- New window (unless reusing current)
+                if reuseWindow is "false" then
+                    keystroke "n" using {command down}
+                    delay 1.0
+                end if
+
+                -- Ensure focused before starting setup
+                set frontmost to true
+                delay 0.5
+
+                -- === TAB LOOP ===
+                repeat with tabIdx from 1 to tabsCount
+
+                    -- Create new tab if not the first tab
+                    if tabIdx > 1 then
+                        keystroke "t" using {command down}
+                        delay 0.4
+                    end if
+
+                    -- Calculate command base index for this tab
+                    set tabCmdBase to (tabIdx - 1) * panesPerTab
+
+                    -- PHASE 1: Create column spine (n-1 horizontal splits)
+                    if numCols > 1 then
+                        repeat numCols - 1 times
+                            keystroke "d" using {command down} -- Split right
+                            delay 0.4
+                        end repeat
+
+                        -- Navigate to leftmost column
+                        repeat numCols - 1 times
+                            key code 123 using {command down, option down} -- Left
+                            delay 0.3
+                        end repeat
+                    end if
+                    delay 0.3
+
+                    -- PHASE 2: Expand columns vertically and type commands inline
+                    set spatialIdx to 1
+
+                    repeat with colIdx from 1 to numCols
+                        set rowsInCol to item colIdx of colCounts
+
+                        -- Type command for this column's anchor (we're already here)
+                        set cmdIndex to tabCmdBase + spatialIdx
+                        if cmdIndex ≤ (count of commands) then
+                            set cmd to item cmdIndex of commands
+                            if cmd is not "" then
+                                set the clipboard to cmd
+                                keystroke "v" using {command down}
+                                key code 36 -- Enter
+                                delay 0.4
+                            end if
+                        end if
+                        set spatialIdx to spatialIdx + 1
+
+                        -- Create vertical splits and type commands for each new pane
+                        if rowsInCol > 1 then
+                            repeat rowsInCol - 1 times
+                                keystroke "d" using {command down, shift down} -- Split down
+                                delay 0.6
+
+                                set cmdIndex to tabCmdBase + spatialIdx
+                                if cmdIndex ≤ (count of commands) then
+                                    set cmd to item cmdIndex of commands
+                                    if cmd is not "" then
+                                        set the clipboard to cmd
+                                        keystroke "v" using {command down}
+                                        key code 36 -- Enter
+                                        delay 0.4
+                                    end if
+                                end if
+                                set spatialIdx to spatialIdx + 1
+                            end repeat
+                        end if
+
+                        -- Navigate to next column anchor (if not last column)
+                        if colIdx < numCols then
+                            delay 0.2
+                            if rowsInCol > 1 then
+                                repeat rowsInCol - 1 times
+                                    key code 126 using {command down, option down} -- Up
+                                    delay 0.15
+                                end repeat
+                            end if
+                            key code 124 using {command down, option down} -- Right
+                            delay 0.2
+                        end if
+                    end repeat
+
+                    -- PHASE 3: Equalize splits
+                    if panesPerTab > 1 then
+                        key code 24 using {command down, control down}
+                        delay 0.4
+                    end if
+
+                    -- PHASE 3.5: Resize columns with multiple rows
+                    -- For each column that has >1 row, navigate to its top pane
+                    -- and push the divider down to shrink the last row
+                    -- First go to top-left
+                    set maxRows to 0
+                    repeat with c in colCounts
+                        if c > maxRows then set maxRows to c
+                    end repeat
+                    repeat maxRows - 1 times
+                        key code 126 using {command down, option down} -- Up
+                        delay 0.1
+                    end repeat
+                    repeat numCols - 1 times
+                        key code 123 using {command down, option down} -- Left
+                        delay 0.1
+                    end repeat
+                    delay 0.2
+
+                    repeat with colIdx from 1 to numCols
+                        set rowsInCol to item colIdx of colCounts
+                        if rowsInCol > 1 then
+                            -- We're at the top pane of this column
+                            -- Push divider down 8 times to shrink bottom pane
+                            repeat 8 times
+                                key code 125 using {command down, control down} -- Cmd+Ctrl+Down
+                                delay 0.08
+                            end repeat
+                        end if
+                        -- Move right to next column (if not last)
+                        if colIdx < numCols then
+                            key code 124 using {command down, option down} -- Right
+                            delay 0.15
+                        end if
+                    end repeat
+
+                    -- PHASE 4: Navigate to first pane (top-left)
+                    delay 0.2
+                    set maxRows to 0
+                    repeat with c in colCounts
+                        if c > maxRows then set maxRows to c
+                    end repeat
+                    repeat maxRows - 1 times
+                        key code 126 using {command down, option down} -- Up
+                        delay 0.12
+                    end repeat
+                    repeat numCols - 1 times
+                        key code 123 using {command down, option down} -- Left
+                        delay 0.12
+                    end repeat
+
+                end repeat
+                -- === END TAB LOOP ===
+
+                -- Return to Tab 1 for user convenience
+                if tabsCount > 1 then
+                    delay 0.2
+                    keystroke "1" using {command down}
+                    delay 0.2
+                end if
+
+            end tell
+        end tell
+
+        -- Success: Restore original clipboard if we saved it
+        if originalClipboard is not missing value then
+            try
+                set the clipboard to originalClipboard
+            end try
+        end if
+
+    on error errMsg
+        -- Error: Restore clipboard before re-throwing
+        if originalClipboard is not missing value then
+            try
+                set the clipboard to originalClipboard
+            end try
+        end if
+        error errMsg
+    end try
+end run
+
+-- Parse "1|2" into {1, 2}
+on parseColumnLayout(spec)
+    set AppleScript's text item delimiters to "|"
+    set parts to text items of spec
+    set AppleScript's text item delimiters to ""
+
+    set colList to {}
+    repeat with p in parts
+        set end of colList to p as integer
+    end repeat
+    return colList
+end parseColumnLayout


### PR DESCRIPTION
## Summary

- Add **column-first layouts** using `|` delimiter (e.g. `1|2`, `2|1`) to complement existing row-first layouts using `-`
- New aliases: `main-side` → `1|2`, `side-main` → `2|1`
- New `layout-column.applescript` with full tab support
- Updated `validate_layout`, `compute_total_panes`, and routing in `layout_dynamic` / `layout_hybrid`

## Motivation

The current row-based layout system (`-` delimiter) cannot express layouts where a column spans the full height while another column is split vertically:

```
┌──────────┬──────┐
│          │  top │
│   main   ├──────┤
│          │  bot │
└──────────┴──────┘
```

This is a very common IDE-style layout (editor left, file browser + terminal right). The `|` delimiter naturally reads as "columns" while `-` reads as "rows", making the syntax intuitive.

## Usage

```yaml
# config.yaml
default_layout: main-side   # or "1|2"
# commands are column-by-column, top-to-bottom:
default_commands:
  - "nvim ."        # left (main)
  - "yazi ./"       # right-top
  - ""              # right-bottom
```

More examples:
- `2|1` / `side-main` → left column split, right main
- `2|3|1` → 3 columns with different row counts

## Design

- Uses `|` as delimiter (vs `-` for rows) — no ambiguity, backward compatible
- `layout-column.applescript` mirrors `layout-dynamic` / `layout-hybrid` with axes swapped:
  - Phase 1: `Cmd+D` creates column spine (vs `Cmd+Shift+D` for rows)
  - Phase 2: `Cmd+Shift+D` expands rows within columns (vs `Cmd+D`)
- Single script handles both single-window and multi-tab modes via `tabs:N` argument
- After equalize, applies resize to shrink the last row in multi-row columns

## Test plan

- [x] Tested `main-side` (`1|2`) layout with single window
- [x] Tested `main-side` with `tabs: 2`
- [x] Verified commands are typed in correct panes (spatial order: column-by-column)
- [x] Verified clipboard is preserved/restored
- [x] Verified existing row layouts (`duo`, `quad`, `dashboard`, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)